### PR TITLE
Put the broken migration back in, with 'correct' capitalization

### DIFF
--- a/ticketee/db/migrate/20150406055658_add_api_key_to_users.rb
+++ b/ticketee/db/migrate/20150406055658_add_api_key_to_users.rb
@@ -1,0 +1,6 @@
+class AddAPIKeyToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :api_key, :string
+    add_index :users, :api_key
+  end
+end


### PR DESCRIPTION
An acronym inflector is defined here for API: https://github.com/shageman/r4ia_examples/blob/master/ticketee/config/initializers/inflections.rb#L13

The change to the migration was made here: https://github.com/shageman/r4ia_examples/commit/30295a846268726eea98ae10878e0734eefc4eed#diff-ebe2ae621e735644776766c5dca2f4c7

I'm guessing the initializer wasn't in effect, when you made that commit?